### PR TITLE
Warning emails has undefined id in the URL

### DIFF
--- a/lib/generate-warning-email.js
+++ b/lib/generate-warning-email.js
@@ -2,7 +2,7 @@ module.exports = data => {
   const document = data.document
   const recipient = data.recipient
   const mailText = `Hei!<br/><br/>${document.userName} har sendt varsel til en av dine elever i MinElev.<br />
-  Mer informasjon om varselet finner du <a href="${process.env.MINELEV_URL}/logs?documentId=${document._id}">på denne siden</a>.`
+  Mer informasjon om varselet finner du <a href="${process.env.MINELEV_URL}/logs?documentId=${document.id}">på denne siden</a>.`
 
   const mail = {
     to: [recipient.email],


### PR DESCRIPTION
The emails sent from MinElev to the contact teachers, should have a direct url to the warning sent to one of their students. Because of changes made to the robot, the ``_id`` property is replaced with ``id``. The underscore from the id prop. should therefore be removed from the email template to avoid "undefined" in the urls.

Ref:
https://github.com/telemark/minelev-saksbehandler-robot/blob/da14b6c1c9083e613f698501436e0df6cd024f8e/lib/steps/save-to-notifications.js#L20